### PR TITLE
fix(dependabot): Ignore Mongo updates >= v5

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,7 +19,7 @@ updates:
       interval: "weekly"
     ignore:
       - dependency-name: "mongo"
-        versions: ["~> 4.4"]
+        versions: [">= 5"]
 
   - package-ecosystem: "docker-compose"
     directories:
@@ -28,4 +28,4 @@ updates:
       interval: "weekly"
     ignore:
       - dependency-name: "mongo"
-        versions: ["~> 4.4"]
+        versions: [">= 5"]


### PR DESCRIPTION
The previous rule was ignoring versions between 4.4 and 5 instead of restricting verions to that range.