### PR TITLE
fix(dependabot): Ignore Mongo updates >= 4.4.19

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,7 +19,7 @@ updates:
       interval: "weekly"
     ignore:
       - dependency-name: "mongo"
-        versions: [">= 5"]
+        versions: [">= 4.4.19"]
 
   - package-ecosystem: "docker-compose"
     directories:
@@ -28,4 +28,4 @@ updates:
       interval: "weekly"
     ignore:
       - dependency-name: "mongo"
-        versions: [">= 5"]
+        versions: [">= 4.4.19"]


### PR DESCRIPTION
Any Mongo version >= 4.4.19 introduces the hardware incompatibilities so we ignore all Mongo updates >= to that