### PR TITLE
chore(it-tools): Get off nightly builds

### DIFF
--- a/services/it-tools/docker-compose.yml
+++ b/services/it-tools/docker-compose.yml
@@ -1,12 +1,12 @@
 services:
   it-tools:
-    image: ghcr.io/sharevb/it-tools:latest
+    image: ghcr.io/sharevb/it-tools:2025.8.6-0325b117
     restart: unless-stopped
     networks:
       - proxy-internal
     labels:
       diun.enable: true
-      diun.include_tags: latest
+      diun.include_tags: ^\d+\.\d+\.\d+(-\w+)?$
       caddy: "tools.{$$INTERNAL_DOMAIN}"
       caddy.reverse_proxy: "{{ upstreams 8080 }}"
 


### PR DESCRIPTION
Latest for this repository means nightly instead of the latest release, so specifying the latest release explicitly instead.