### PR TITLE
chore(beszel): Agent volume mount for fingerprint

### DIFF
--- a/services/beszel/agent/docker-compose.yml
+++ b/services/beszel/agent/docker-compose.yml
@@ -3,6 +3,7 @@ services:
     image: ghcr.io/henrygd/beszel/beszel-agent:0
     restart: always
     volumes:
+      - data:/var/lib/beszel-agent
       - socket-proxy:/socket-proxy:ro
     healthcheck:
       test: ["CMD", "/agent", "health"]
@@ -27,5 +28,6 @@ secrets:
     environment: BESZEL_AGENT_TOKEN
 
 volumes:
+  data:
   socket-proxy:
     external: true

--- a/services/beszel/hub/docker-compose.yml
+++ b/services/beszel/hub/docker-compose.yml
@@ -28,6 +28,7 @@ services:
       beszel:
         condition: service_healthy
     volumes:
+      - data-agent:/var/lib/beszel-agent
       - beszel-socket:/beszel_socket
       - socket-proxy:/socket-proxy:ro
     healthcheck:
@@ -54,6 +55,7 @@ secrets:
 
 volumes:
   data:
+  data-agent:
   beszel-socket:
   socket-proxy:
     external: true


### PR DESCRIPTION
Mount a persistent volume for Beszel agents to ensure device fingerprints stay consistent.