### PR TITLE
chore(socket-proxy): Make regex more restrictive to endpoints used by services

### DIFF
--- a/services/socket-proxy/docker-compose.yml
+++ b/services/socket-proxy/docker-compose.yml
@@ -16,8 +16,8 @@ services:
       SP_ALLOWHEALTHCHECK: true
       SP_LISTENIP: 0.0.0.0
       SP_LOGLEVEL: ${SOCKET_PROXY_LOG_LEVEL:-INFO}
-      SP_ALLOW_GET: /(v1\..{1,2}/)?(version|info|containers/.*|images/.*|networks(/.*)?|events.*)
-      SP_ALLOW_HEAD: /_ping
+      SP_ALLOW_GET: (/v1\..{1,2})?/(_ping|version|info|containers/(json|\w+/stats(\?\S+)?)|images/\S+/json|networks(/.*)?|events(\?\S+)?)
+      SP_ALLOW_HEAD: (/v1\..{1,2})?/_ping
     networks:
       - beszel-agent
       - caddy


### PR DESCRIPTION
Ensures unsafe GET endpoints cannot be called (mainly for `/container/...`)