### PR TITLE
feat(immich): Explicitly disable custom URLs for proxying

### DIFF
--- a/services/immich/docker-compose.yml
+++ b/services/immich/docker-compose.yml
@@ -58,6 +58,7 @@ services:
             "singleImageGallery": false,
             "singleItemAutoOpen": true,
             "downloadOriginalPhoto": true,
+            "allowSlugLinks": false,
             "allowDownloadAll": 1,
             "showHomePage": true,
             "showGalleryTitle": true,


### PR DESCRIPTION
This is already blocked by Caddy, but adding this configuration as a  second stop