### PR TITLE
chore(homepage): Better base Home Assistant URL

### DIFF
--- a/services/homepage/docker-compose.yml
+++ b/services/homepage/docker-compose.yml
@@ -177,7 +177,7 @@ configs:
               - Home:
                   - Home Assistant:
                       icon: home-assistant
-                      href: https://ha.{{HOMEPAGE_VAR_INTERNAL_DOMAIN}}/auth/oidc/welcome
+                      href: https://ha.{{HOMEPAGE_VAR_INTERNAL_DOMAIN}}
                       description: Home automation
                       proxmoxNode: pve
                       proxmoxVMID: {{HOMEPAGE_VAR_PROXMOX_HAOS_VMID}}


### PR DESCRIPTION
Enabled via the v1.0.1 release of the HACS OIDC plugin, which now handles SSO from the main page