### PR TITLE
fix(caddy): Comment out build key

### DIFF
--- a/services/caddy/docker-compose.yml
+++ b/services/caddy/docker-compose.yml
@@ -1,7 +1,7 @@
 services:
   caddy:
     image: ghcr.io/eliodinino/homelab/caddy:latest
-    build: .
+    # build: . # Uncomment for local development
     restart: always
     volumes:
       - data:/data


### PR DESCRIPTION
Portainer does not properly fetch the remote image when the build key is present