### PR TITLE
fix(cloudflared): Remove symlink due to Portainer

### DIFF
--- a/services/cloudflared/99-cloudflared-udp.conf
+++ b/services/cloudflared/99-cloudflared-udp.conf
@@ -1,1 +1,0 @@
-../../tools/sysctl/99-cloudflared-udp.conf

--- a/services/cloudflared/NOTE.md
+++ b/services/cloudflared/NOTE.md
@@ -1,0 +1,3 @@
+# Cloudflared Notes
+
+To ensure maximum performance, apply [the corresponding sysctl config file](../../tools/sysctl/99-cloudflared-udp.conf) to your system. This configuration optimizes the kernel parameters for higher UDP traffic throughput.


### PR DESCRIPTION
Portainer blocks deploying repositories that contain symlinks for security reasons, so it has been replaced with NOTE.md that links to the same file.