### PR TITLE
fix(docker): Allocate smaller networks

### DIFF
--- a/tools/docker/daemon.json
+++ b/tools/docker/daemon.json
@@ -1,0 +1,8 @@
+{
+  "default-address-pools": [
+    {
+      "base": "172.16.0.0/12",
+      "size": 24
+    }
+  ]
+}


### PR DESCRIPTION
The default allocation uses up too much of the address space so I was unable to create more networks. Adjust the allocation size (and recreate all the networks manually) to prevent the issue.