### PR TITLE
chore(stirling-pdf): Tighten CSP policy

### DIFF
--- a/services/stirling-pdf/docker-compose.yml
+++ b/services/stirling-pdf/docker-compose.yml
@@ -70,9 +70,9 @@ services:
       caddy.import.header.Content-Security-Policy: >
         "
         default-src 'self' blob: data: 'unsafe-inline' 'unsafe-eval';
-        connect-src 'self' blob: data: https://api.iconify.design https://cdn.jsdelivr.net https://supabase.stirling.com/functions/v1/updates https://*.sentry.io;
-        font-src 'self' https://fonts.gstatic.com;
-        style-src 'self' 'unsafe-inline' https://fonts.googleapis.com;
+        connect-src 'self' blob: data: https://supabase.stirling.com/functions/v1/updates https://*.sentry.io;
+        font-src 'self';
+        style-src 'self' 'unsafe-inline';
         report-uri {$$SENTRY_CSP_ENDPOINT}&sentry_environment={$$ENVIRONMENT};
         report-to csp-endpoint;
         "


### PR DESCRIPTION
Less dependencies are required now that more things are bundled into the app