### PR TITLE
chore(git): Remove .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,0 @@
-docker-compose.yml linguist-language=Dockerfile


### PR DESCRIPTION
This has been messing up compose file previews on GitHub