### PR TITLE
fix(portainer): Trusted origin scheme

### DIFF
--- a/services/portainer/compose.yml
+++ b/services/portainer/compose.yml
@@ -12,7 +12,7 @@ services:
     ports:
       - 9443:9443
     environment:
-      TRUSTED_ORIGINS: portainer.${INTERNAL_DOMAIN:?error}
+      TRUSTED_ORIGINS: https://portainer.${INTERNAL_DOMAIN:?error}
     networks:
       - proxy-internal
     labels:


### PR DESCRIPTION
A breaking change was introducted in 2.41.0 that requires the scheme to be added to trusted origins