### PR TITLE
feat(caddy): Proxy redirects through landing page

### DIFF
--- a/services/.env.example
+++ b/services/.env.example
@@ -57,6 +57,7 @@ PROXMOX_HOST="localhost"
 HAOS_HOST="localhost"
 # Ref: https://docs.sentry.io/platforms/go/security-policy-reporting/
 SENTRY_CSP_ENDPOINT="https://example.ingest.sentry.io/api/1234567890/security/?sentry_key=example_sentry_key"
+HOMELAB_EXTERNAL_SUBDOMAIN="homelab"
 INGEST_EXTERNAL_SUBDOMAIN="ingest"
 SABLIER_LOG_LEVEL=""
 

--- a/services/caddy/compose.yaml
+++ b/services/caddy/compose.yaml
@@ -238,8 +238,8 @@ services:
       - proxy-immich-upload-public
       - proxy-pingvin-share-x
     environment:
-      INTERNAL_DOMAIN: ${INTERNAL_DOMAIN:?error}
       EXTERNAL_DOMAIN: ${EXTERNAL_DOMAIN:?error}
+      HOMELAB_EXTERNAL_SUBDOMAIN: ${HOMELAB_EXTERNAL_SUBDOMAIN:?error}
       INGEST_EXTERNAL_SUBDOMAIN: ${INGEST_EXTERNAL_SUBDOMAIN:?error}
       IMMICH_EXTERNAL_SUBDOMAIN: ${IMMICH_EXTERNAL_SUBDOMAIN:?error}
       IMMICH_UPLOAD_EXTERNAL_SUBDOMAIN: ${IMMICH_UPLOAD_EXTERNAL_SUBDOMAIN:?error}
@@ -276,7 +276,7 @@ configs:
         }
 
         handle {
-          redir https://photos.{$$INTERNAL_DOMAIN}{uri} permanent
+          redir https://{$$HOMELAB_EXTERNAL_SUBDOMAIN}.{$$EXTERNAL_DOMAIN}?next=photos{uri} temporary
         }
       }
 
@@ -314,7 +314,7 @@ configs:
         }
 
         handle {
-          redir https://photos.{$$INTERNAL_DOMAIN}{uri} permanent
+          redir https://{$$HOMELAB_EXTERNAL_SUBDOMAIN}.{$$EXTERNAL_DOMAIN}?next=photos{uri} temporary
         }
       }
 
@@ -325,7 +325,7 @@ configs:
         }
 
         handle {
-          redir https://share.{$$INTERNAL_DOMAIN}{uri} permanent
+          redir https://{$$HOMELAB_EXTERNAL_SUBDOMAIN}.{$$EXTERNAL_DOMAIN}?next=share{uri} temporary
         }
       }
 


### PR DESCRIPTION
Previously, if an external user clicked on a link within a publicly exposed service that redirected internally their page would hang since they don’t have network access. Now, those requests go through the external landing page for a better experience.